### PR TITLE
Fixed the error with musescore3 in Dockerfile.gpu

### DIFF
--- a/docker/Dockerfile.gpu
+++ b/docker/Dockerfile.gpu
@@ -3,6 +3,7 @@ FROM tensorflow/tensorflow:2.10.1-gpu
 RUN rm /etc/apt/sources.list.d/cuda.list
 
 RUN apt-get update
+RUN add-apt-repository ppa:mscore-ubuntu/mscore3-stable
 RUN apt-get install -y unzip graphviz curl musescore3
 
 RUN pip install --upgrade pip


### PR DESCRIPTION
`RUN add-apt-repository ppa:mscore-ubuntu/mscore3-stable` without this installation failed in Ubuntu 20.04.6 LTS.